### PR TITLE
Remove command windows when starting PHP processes

### DIFF
--- a/server/v3.04/function.php
+++ b/server/v3.04/function.php
@@ -347,7 +347,7 @@ function call_script($script, $priority = 1, $plugin = FALSE)
 		// Below Normal Priority
 		if(getenv("OS") == "Windows_NT")
 		{
-			pclose(popen("start /B /BELOWNORMAL php-win $script", "r"));// This will execute without waiting for it to finish
+			pclose(popen("start /BELOWNORMAL /B php-win $script", "r"));// This will execute without waiting for it to finish
 		}
 		else
 		{


### PR DESCRIPTION
Windows: Prevent a 'command' window from appearing each time a new PHP process is started

this is done by using start /B
